### PR TITLE
Remove user agent sniffing so touch events work on all mobile devices

### DIFF
--- a/javascripts/raphael.sketchpad.js
+++ b/javascripts/raphael.sketchpad.js
@@ -266,12 +266,9 @@
 					$(document).unbind("mouseup", _mouseup);
 
 					// iPhone Events
-					var agent = navigator.userAgent;
-					if (agent.indexOf("iPhone") > 0 || agent.indexOf("iPod") > 0) {
-						$(_container).unbind("touchstart", _touchstart);
-						$(_container).unbind("touchmove", _touchmove);
-						$(_container).unbind("touchend", _touchend);
-					}
+					$(_container).unbind("touchstart", _touchstart);
+					$(_container).unbind("touchmove", _touchmove);
+					$(_container).unbind("touchend", _touchend);
 				} else {
 					// Cursor is crosshair, so it looks like we can do something.
 					$(_container).css("cursor", "crosshair");
@@ -284,12 +281,9 @@
 					$(document).mouseup(_mouseup);
 
 					// iPhone Events
-					var agent = navigator.userAgent;
-					if (agent.indexOf("iPhone") > 0 || agent.indexOf("iPod") > 0) {
-						$(_container).bind("touchstart", _touchstart);
-						$(_container).bind("touchmove", _touchmove);
-						$(_container).bind("touchend", _touchend);
-					}
+					$(_container).bind("touchstart", _touchstart);
+					$(_container).bind("touchmove", _touchmove);
+					$(_container).bind("touchend", _touchend);
 				}
 			} else {
 				// Reverse the settings above.
@@ -300,12 +294,9 @@
 				$(document).unbind("mouseup", _mouseup);
 				
 				// iPhone Events
-				var agent = navigator.userAgent;
-				if (agent.indexOf("iPhone") > 0 || agent.indexOf("iPod") > 0) {
-					$(_container).unbind("touchstart", _touchstart);
-					$(_container).unbind("touchmove", _touchmove);
-					$(_container).unbind("touchend", _touchend);
-				}
+				$(_container).unbind("touchstart", _touchstart);
+				$(_container).unbind("touchmove", _touchmove);
+				$(_container).unbind("touchend", _touchend);
 			}
 			
 			return self; // function-chaining


### PR DESCRIPTION
I saw that you were manually detecting iPod Touches and iPhones for the touch events, and, as a result, it wasn't working on my iPad or Android devices. So, I went ahead and removed those conditionals so it will work of all devices that support them.
