### PR TITLE
Update the current strokes state after erasing

### DIFF
--- a/_includes/how- to-zoom-scale
+++ b/_includes/how- to-zoom-scale
@@ -1,0 +1,84 @@
+<html>
+<head>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+<script type="text/javascript" src="javascripts/raphael-2.0.1.js"></script>
+<script type="text/javascript" src="javascripts/json2.min.js"></script>
+<script type="text/javascript" src="javascripts/raphael.sketchpad.js"></script>
+</head>
+
+<body>
+
+  <div id="sketchpad_editor"></div>
+      <div id="viewer" style="display:none">
+          <h3>Viewer</h3>
+          <p>
+              <a href="javascript:void(0);" id="update_sketchpad_viewer"></a>
+          </p>
+          <div style="height:650px;" class="widget">
+              <div id="sketchpad_viewer"></div>
+          </div>
+      </div>
+
+
+      <div id="result_div" style="display: none">
+          <h3>Result</h3>
+          <p>
+              The sketch is stored as JSON in an input field.
+          </p>
+          <form action="" method="post" onsubmit="return false;">
+              <textarea id="input1" name="input1"></textarea>
+          </form>
+
+  
+  
+  <script type="text/javascript">
+  <img src="someBackgroundImg.jpg" alt="Smiley face" height="42" width="42">
+  
+    currH = img.height;
+    origH = img.height;
+    currW = img.width;
+    origW = img.width;
+    incW = 20;
+    incH = incW / origW * origH;
+    
+    sketchpad_editor = Raphael.sketchpad("sketchpad_editor", {
+        width: origW,
+        height: origH,
+        editing: true, // true is default
+    });
+    
+  sketchpad_viewer = Raphael.sketchpad("sketchpad_viewer", {
+            width: origW,
+            height: origH,
+            editing: false,
+        });
+
+
+  var _c = sketchpad_editor.canvas(); // attach events to the sketchpad canvas 
+
+            if (_c.addEventListener) {
+                // IE9, Chrome, Safari, Opera
+                _c.addEventListener("mousewheel", MouseWheelHandler, false);
+                // Firefox
+                _c.addEventListener("DOMMouseScroll", MouseWheelHandler, false);
+            } else {
+                _c.attachEvent("onmousewheel", MouseWheelHandler); // IE 6/7/
+            }
+
+            function MouseWheelHandler(e) {
+
+                // cross-browser wheel delta
+                var e = window.event || e; // old IE support
+                var delta = Math.max(-1, Math.min(1, (e.wheelDelta || -e.detail)));
+
+                sketchpad_editor.scale(currW + incW * delta, currH + incH * delta);
+                incH = incW / currW * currH;
+                currW = currW + incW * delta;
+                currH = currH + incH * delta;
+
+                return false;
+            }
+            
+        </script>
+        </body>
+        </html>

--- a/_includes/how- to-zoom-scale
+++ b/_includes/how- to-zoom-scale
@@ -1,84 +1,117 @@
 <html>
+
 <head>
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
-<script type="text/javascript" src="javascripts/raphael-2.0.1.js"></script>
-<script type="text/javascript" src="javascripts/json2.min.js"></script>
-<script type="text/javascript" src="javascripts/raphael.sketchpad.js"></script>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+    <script type="text/javascript" src="js/raphael.js"></script>
+    <script type="text/javascript" src="js/raphael.sketchpad.js"></script>
 </head>
 
 <body>
+    <div class="container">
 
-  <div id="sketchpad_editor"></div>
-      <div id="viewer" style="display:none">
-          <h3>Viewer</h3>
-          <p>
-              <a href="javascript:void(0);" id="update_sketchpad_viewer"></a>
-          </p>
-          <div style="height:650px;" class="widget">
-              <div id="sketchpad_viewer"></div>
-          </div>
-      </div>
+        <div style="height:500px;" class="widget">
+            <div id="sketchpad_editor"></div>
 
+        </div>
+        <div id="viewer" style="display:none">
+            <h3>Viewer</h3>
+            <p>
+                <a href="javascript:void(0);" id="update_sketchpad_viewer"></a>
+            </p>
+            <div style="height:500px;" class="widget">
+                <div id="sketchpad_viewer"></div>
+            </div>
+        </div>
+    </div>
 
-      <div id="result_div" style="display: none">
-          <h3>Result</h3>
-          <p>
-              The sketch is stored as JSON in an input field.
-          </p>
-          <form action="" method="post" onsubmit="return false;">
-              <textarea id="input1" name="input1"></textarea>
-          </form>
+    <div id="result_div" style="display: none">
+        <h3>Result</h3>
+        <p>
+            The sketch is stored as JSON in an input field.
+        </p>
+        <form action="" method="post" onsubmit="return false;">
+            <textarea id="input1" name="input1"></textarea>
+        </form>
+    </div>
 
-  
-  
-  <script type="text/javascript">
-  <img src="someBackgroundImg.jpg" alt="Smiley face" height="42" width="42">
-  
-    currH = img.height;
-    origH = img.height;
-    currW = img.width;
-    origW = img.width;
-    incW = 20;
-    incH = incW / origW * origH;
-    
-    sketchpad_editor = Raphael.sketchpad("sketchpad_editor", {
-        width: origW,
-        height: origH,
-        editing: true, // true is default
-    });
-    
-  sketchpad_viewer = Raphael.sketchpad("sketchpad_viewer", {
+        <a id="iconPlus"> <span class="glyphicon glyphicon-zoom-in" style="padding:1px 0px 10px 0px;font-size:30px"></span> </a>
+        <br>
+        <a id="iconMinus"> <span class="glyphicon glyphicon-zoom-out" style="font-size: 30px"></span> </a>
+
+    <img id="img" src="http://www.clipartkid.com/images/265/20-by-20-sectioned-grid-clipart-etc-SVRWIs-clipart.gif" alt="W3Schools.com" style="display: none">
+
+    <script type="text/javascript">
+        strokes = [];
+        img = document.getElementById('img');
+        currH = 500;
+        origH = 500;
+        currW = 600;
+        origW = 600;
+        incW = 20;
+        incH = incW / origW * origH;
+
+        sketchpad_editor = Raphael.sketchpad("sketchpad_editor", {
+            width: origW,
+            height: origH,
+            editing: true, // true is default
+        });
+
+        sketchpad_viewer = Raphael.sketchpad("sketchpad_viewer", {
             width: origW,
             height: origH,
             editing: false,
         });
 
+        sketchpad_editor.paper().image(img.src, 0, 0, origW, origH).toBack();
 
-  var _c = sketchpad_editor.canvas(); // attach events to the sketchpad canvas 
+        $("#input1").val(sketchpad_editor.json()); //sets the value to input1
+        sketchpad_viewer.json($('#input1').val());
 
-            if (_c.addEventListener) {
-                // IE9, Chrome, Safari, Opera
-                _c.addEventListener("mousewheel", MouseWheelHandler, false);
-                // Firefox
-                _c.addEventListener("DOMMouseScroll", MouseWheelHandler, false);
-            } else {
-                _c.attachEvent("onmousewheel", MouseWheelHandler); // IE 6/7/
-            }
+        var _c = sketchpad_editor.canvas(); // attach events to the sketchpad canvas
 
-            function MouseWheelHandler(e) {
+        if (_c.addEventListener) {
+            // IE9, Chrome, Safari, Opera
+            _c.addEventListener("mousewheel", MouseWheelHandler, false);
+            // Firefox
+            _c.addEventListener("DOMMouseScroll", MouseWheelHandler, false);
+        } else {
+            _c.attachEvent("onmousewheel", MouseWheelHandler); // IE 6/7/
+        }
 
-                // cross-browser wheel delta
-                var e = window.event || e; // old IE support
-                var delta = Math.max(-1, Math.min(1, (e.wheelDelta || -e.detail)));
+        function MouseWheelHandler(e) {
 
-                sketchpad_editor.scale(currW + incW * delta, currH + incH * delta);
-                incH = incW / currW * currH;
-                currW = currW + incW * delta;
-                currH = currH + incH * delta;
+            // cross-browser wheel delta
+            var e = window.event || e; // old IE support
+            var delta = Math.max(-1, Math.min(1, (e.wheelDelta || -e.detail)));
 
-                return false;
-            }
-            
-        </script>
-        </body>
-        </html>
+            sketchpad_editor.scale(currW + incW * delta, currH + incH * delta);
+            sketchpad_editor.paper().image(img.src, 0, 0, origW, origH).toBack();
+            incH = incW / currW * currH;
+            currW = currW + incW * delta;
+            currH = currH + incH * delta;
+
+            return false;
+        }
+
+        $("#iconPlus").click(function() {
+            sketchpad_editor.scale(currW + incW, currH + incH);
+            sketchpad_editor.paper().image(img.src, 0, 0, origW, origH).toBack();
+            incH = incW / currW * currH;
+            currW = currW + incW;
+            currH = currH + incH;
+        });
+
+        $("#iconMinus").click(function() {
+            sketchpad_editor.scale(currW - incW, currH - incH);
+            sketchpad_editor.paper().image(img.src, 0, 0, origW, origH).toBack();
+            incH = incW / currW * currH;
+            currW = currW - incW;
+            currH = currH - incH;
+        });
+        
+    </script>
+</body>
+
+
+</html>

--- a/src/raphael.sketchpad.js
+++ b/src/raphael.sketchpad.js
@@ -371,17 +371,28 @@
 					type: "erase",
 					stroke: stroke
 				});
-				
+				    // convert selected svg path to string
+                	function svg_path_to_string(path) {
+                	 var str = "";
+                    	for (var i = 0, n = path.length; i < n; i++) {
+                        	var point = path[i];
+                        	str += point[0] + point[1] + "," + point[2];
+                	 }
+                    	return str;
+                	}
+
+                	stroke_path = svg_path_to_string(stroke.path);
 				for (var i = 0, n = _strokes.length; i < n; i++) {
 					var s = _strokes[i];
-					if (equiv(s, stroke)) {
+					  if (s && s.path && (s.path == stroke_path)) {
 						_strokes.splice(i, 1);
 					}
 				}
+				this.remove();
 				
 				_fire_change();
 				
-				this.remove();
+				
 			}
 		};
 		
@@ -548,7 +559,7 @@
 						case "erase":
 							for (var s = 0, n = strokes.length; s < n; s++) {
 								var stroke = strokes[s];
-								if (equiv(stroke, action.stroke)) {
+								  if (stroke_i && stroke_i.path && (stroke_i.path == action.stroke.path)) {
 									strokes.splice(s, 1);
 								}
 							}


### PR DESCRIPTION
When using the erase button the line would be erased visually, but it wouldn't remove the respective strokes from the array. The equiv function seems to be outdated and the comparison fails.

If saving of the strokes (offline raster image) is wanted (with RaphaelExport, canvg) this update will render the correct strokes.
